### PR TITLE
chore: s3 관련 workflow 수정

### DIFF
--- a/.github/workflows/Front-build.yaml
+++ b/.github/workflows/Front-build.yaml
@@ -55,7 +55,7 @@ jobs:
         env:
           BUCKET_NAME: ${{ secrets.AWS_S3_BUCKET_NAME }}
         run: |
-          aws s3 sync ./build s3://$BUCKET_NAME --delete
+          aws s3 sync ./build s3://$BUCKET_NAME/static --delete
       
       # CloudFront 캐시를 무효화합니다.
       - name: CloudFront Invalidation


### PR DESCRIPTION
1. s3에서 빌드 시에 빌드파일에 없는 파일들은 자동으로 삭제되는 workflow가 작성되어있어 /static으로 경로 한정하게 수정